### PR TITLE
Fixing the button state on fresh session.

### DIFF
--- a/ratt-signal.js
+++ b/ratt-signal.js
@@ -2,7 +2,6 @@ AllUsers = new Mongo.Collection('users');
 
 if (Meteor.isClient) {
 	var db_ready = false;
-	var user_id = Session.get('user_id');
 	Session.set('light_image', 'signal.png');
 	//wait for db to be ready
 	Meteor.subscribe('db_ready', function(){
@@ -10,6 +9,7 @@ if (Meteor.isClient) {
 			db_ready = true;
 			//get previous user_id
 			//create a new user if doesn't exist
+			var user_id = Session.get('user_id');
 			if(AllUsers.find({"_id": user_id}).count() < 1){
 				user_id = Random.id();
 				AllUsers.insert({_id: user_id, checked_in: 0});
@@ -45,6 +45,7 @@ if (Meteor.isClient) {
 			}			
 		},
 		activate_status: function() {
+			var user_id = Session.get('user_id');
 			var info = AllUsers.findOne({_id: user_id});
 			if(info == null){
 				//default
@@ -70,6 +71,7 @@ if (Meteor.isClient) {
       event.preventDefault();
 			//debugger;
 			//console.log("Triggered");
+			var user_id = Session.get("user_id");
 			var info = AllUsers.findOne({_id: user_id});
 			if(!(info['checked_in'] == 1) && !event.target.name.value){
 				alert("Please enter your name!");


### PR DESCRIPTION
On new sessions, the Activate/Deactivate button would not update.
- Changing it so we read the Session value instead of a global variable. When the global variable was overwritten by the `user_id = Random.id();` on fresh instances, this would break the binding and `activate_status` would not be invoked.
